### PR TITLE
Extended QTMarlin.pro for OS X

### DIFF
--- a/QTMarlin.pro
+++ b/QTMarlin.pro
@@ -36,3 +36,26 @@ win32 {
 unix:!macx {
     LIBS += -ludev
 }
+
+macx {
+QWT_DIR=/usr/local/Cellar/qwt/6.0.1/lib/   #brew install qwt
+
+TEMPLATE = app
+TARGET = 
+DEPENDPATH = .
+INCLUDEPATH = .
+INCLUDEPATH += $$QEXTSERIAL_DIR/src
+INCLUDEPATH += $$QWT_DIR/qwt.framework/Headers/
+INCLUDEPATH += $$QSERIALDEVICE_DIR/src/qserialdeviceenumerator
+INCLUDEPATH += $$QSERIALDEVICE_DIR/src/qserialdevice
+
+QMAKE_LIBDIR = $$QEXTSERIAL_DIR/src/build/
+QMAKE_LIBDIR += $$QSERIALDEVICE_DIR/src/build/release
+
+LIBS = $$QEXTSERIAL_DIR/src/build/libqextserialport.dylib
+LIBS += -lqserialdevice 
+LIBS += -F$$QWT_DIR -framework qwt -framework IOKit -framework Foundation
+
+QMAKE_POST_LINK += QWT_DIR=$$QWT_DIR QEXTSERIAL_DIR=$$QEXTSERIAL_DIR ./postmake_osx.sh
+}
+

--- a/postmake_osx.sh
+++ b/postmake_osx.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set +x
+
+cp -R $QWT_DIR/qwt.framework QTMarlin.app/Contents/Resources
+cp $QEXTSERIAL_DIR/src/build/libqextserialport.* QTMarlin.app/Contents/Resources
+
+install_name_tool -change qwt.framework/Versions/6/qwt @loader_path/../Resources/qwt.framework/Versions/6/qwt QTMarlin.app/Contents/MacOS/QTMarlin
+install_name_tool -change libqextserialport.1.dylib @loader_path/../Resources/libqextserialport.1.dylib QTMarlin.app/Contents/MacOS/QTMarlin  


### PR DESCRIPTION
quick and dirty fix for OS X. Maybe the postscript isn't necessary,
when using proper include paths, but it works.
